### PR TITLE
Return checklist items for todo queries

### DIFF
--- a/tests/test_things_server.py
+++ b/tests/test_things_server.py
@@ -1,0 +1,38 @@
+import pytest
+from things_server import get_todos, get_today, search_todos
+
+
+@pytest.mark.asyncio
+async def test_get_todos_includes_checklist(mocker, mock_todo):
+    mock_things_todos = mocker.patch('things.todos')
+    mock_things_todos.return_value = [mock_todo]
+
+    result = await get_todos.fn(include_items=True)
+
+    assert "Checklist:" in result
+    assert "First item" in result
+    mock_things_todos.assert_called_once_with(project=None, start=None, include_items=True)
+
+
+@pytest.mark.asyncio
+async def test_get_today_includes_checklist(mocker, mock_todo):
+    mock_today = mocker.patch('things.today')
+    mock_today.return_value = [mock_todo]
+
+    result = await get_today.fn()
+
+    assert "Checklist:" in result
+    assert "First item" in result
+    mock_today.assert_called_once_with(include_items=True)
+
+
+@pytest.mark.asyncio
+async def test_search_todos_includes_checklist(mocker, mock_todo):
+    mock_search = mocker.patch('things.search')
+    mock_search.return_value = [mock_todo]
+
+    result = await search_todos.fn("Test")
+
+    assert "Checklist:" in result
+    assert "First item" in result
+    mock_search.assert_called_once_with("Test", include_items=True)

--- a/things_server.py
+++ b/things_server.py
@@ -16,7 +16,7 @@ mcp = FastMCP("Things")
 @mcp.tool
 async def get_inbox() -> str:
     """Get todos from Inbox"""
-    todos = things.inbox()
+    todos = things.inbox(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -25,7 +25,7 @@ async def get_inbox() -> str:
 @mcp.tool
 async def get_today() -> str:
     """Get todos due today"""
-    todos = things.today()
+    todos = things.today(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -34,7 +34,7 @@ async def get_today() -> str:
 @mcp.tool
 async def get_upcoming() -> str:
     """Get upcoming todos"""
-    todos = things.upcoming()
+    todos = things.upcoming(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -43,7 +43,7 @@ async def get_upcoming() -> str:
 @mcp.tool
 async def get_anytime() -> str:
     """Get todos from Anytime list"""
-    todos = things.anytime()
+    todos = things.anytime(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -52,7 +52,7 @@ async def get_anytime() -> str:
 @mcp.tool
 async def get_someday() -> str:
     """Get todos from Someday list"""
-    todos = things.someday()
+    todos = things.someday(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -66,7 +66,7 @@ async def get_logbook(period: str = "7d", limit: int = 50) -> str:
         period: Time period to look back (e.g., '3d', '1w', '2m', '1y'). Defaults to '7d'
         limit: Maximum number of entries to return. Defaults to 50
     """
-    todos = things.last(period, status='completed')
+    todos = things.last(period, status='completed', include_items=True)
     if todos and len(todos) > limit:
         todos = todos[:limit]
     if not todos:
@@ -77,7 +77,7 @@ async def get_logbook(period: str = "7d", limit: int = 50) -> str:
 @mcp.tool
 async def get_trash() -> str:
     """Get trashed todos"""
-    todos = things.trash()
+    todos = things.trash(include_items=True)
     if not todos:
         return "No items found"
     formatted_todos = [format_todo(todo) for todo in todos]
@@ -97,7 +97,7 @@ async def get_todos(project_uuid: str = None, include_items: bool = True) -> str
         if not project or project.get('type') != 'project':
             return f"Error: Invalid project UUID '{project_uuid}'"
     
-    todos = things.todos(project=project_uuid, start=None)
+    todos = things.todos(project=project_uuid, start=None, include_items=include_items)
     if not todos:
         return "No todos found"
     
@@ -154,7 +154,7 @@ async def get_tagged_items(tag: str) -> str:
     Args:
         tag: Tag title to filter by
     """
-    todos = things.todos(tag=tag)
+    todos = things.todos(tag=tag, include_items=True)
     if not todos:
         return f"No items found with tag '{tag}'"
     
@@ -169,7 +169,7 @@ async def search_todos(query: str) -> str:
     Args:
         query: Search term to look for in todo titles and notes
     """
-    todos = things.search(query)
+    todos = things.search(query, include_items=True)
     if not todos:
         return f"No todos found matching '{query}'"
     
@@ -209,7 +209,7 @@ async def search_advanced(
     if type:
         search_params["type"] = type
     
-    todos = things.todos(**search_params)
+    todos = things.todos(include_items=True, **search_params)
     if not todos:
         return "No matching todos found"
     
@@ -224,7 +224,7 @@ async def get_recent(period: str) -> str:
     Args:
         period: Time period (e.g., '3d', '1w', '2m', '1y')
     """
-    todos = things.last(period)
+    todos = things.last(period, include_items=True)
     if not todos:
         return f"No items found in the last {period}"
     


### PR DESCRIPTION
## Summary
- ensure all todo retrieval endpoints include checklist items
- add tests verifying checklist items are returned for todo, today and search endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979555cdb4832a98ec69f98aea68bd